### PR TITLE
msm_fb: display: Enable display debugging through mdp debugfs

### DIFF
--- a/drivers/video/msm/Kconfig
+++ b/drivers/video/msm/Kconfig
@@ -45,6 +45,11 @@ config FB_MSM_MDP_HW
 config FB_MSM_MDSS_COMMON
 	bool
 
+config MDP_DEBUG_FS
+	depends on DEBUG_FS
+	bool "MDP Debug FS"
+	default n
+
 choice
 	prompt "MDP HW version"
 	default FB_MSM_MDP22

--- a/drivers/video/msm/Makefile
+++ b/drivers/video/msm/Makefile
@@ -11,8 +11,7 @@ obj-$(CONFIG_FB_BACKLIGHT) += msm_fb_bl.o
 ifeq ($(CONFIG_FB_MSM_MDP_HW),y)
 # MDP
 obj-y += mdp.o
-
-obj-$(CONFIG_DEBUG_FS) += mdp_debugfs.o
+obj-$(CONFIG_MDP_DEBUG_FS) += mdp_debugfs.o
 
 ifeq ($(CONFIG_FB_MSM_MDP40),y)
 obj-y += mdp4_util.o

--- a/drivers/video/msm/mdp.c
+++ b/drivers/video/msm/mdp.c
@@ -2,7 +2,7 @@
  *
  * MSM MDP Interface (used by framebuffer core)
  *
- * Copyright (c) 2007-2012, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2007-2013, 2016 The Linux Foundation. All rights reserved.
  * Copyright (C) 2007 Google Incorporated
  *
  * This software is licensed under the terms of the GNU General Public
@@ -3257,7 +3257,7 @@ static int __init mdp_driver_init(void)
 		return ret;
 	}
 
-#if defined(CONFIG_DEBUG_FS)
+#if defined(CONFIG_MDP_DEBUG_FS)
 	mdp_debugfs_init();
 #endif
 


### PR DESCRIPTION
Change the config from DEBUG_FS to MDP_DEBUG_FS to dump and
write the MDP, MDDI and HDMI debug registers. By default
CONFIG_MDP_DEBUG_FS should be disabled and can be enabled
through defconfig file.

Change-Id: I2ed8dcc30b19a80912734ec13f24a67351c38315
Signed-off-by: Raghavendra Ambadas <rambad@codeaurora.org>
Signed-off-by: Naseer Ahmed <naseer@codeaurora.org>
BUG=26404525
CVE-2016-2443
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>